### PR TITLE
ci: bump version with sed instead of toml-editor action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Generate Package Version
-        id: version
         shell: pwsh
-        run: Write-Host "::set-output name=version::$('${{ github.event.release.tag_name }}'.substring(1))"
+        run: Add-Content -Path $env:GITHUB_ENV -Value "VERSION=$('${{ github.event.release.tag_name }}'.substring(1))"
 
       - name: Set Package Version
-        uses: ciiiii/toml-editor@1.0.0
-        with:
-          file: Cargo.toml
-          key: package.version
-          value: ${{ steps.version.outputs.version }}
+        run: sed -i "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/g" Cargo.toml
 
       - name: Stash Versioned Cargo.toml
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The release build was failing because the `ciiiii/toml-editor@1.0.0` action used to bump `package.version` in `Cargo.toml` during releases is broken.

This switches to the same `sed`-based approach already used by [`grey`](https://github.com/SierraSoftworks/grey):

- Write the release version (tag name without the leading `v`) into the `VERSION` environment variable.
- Replace the version placeholder directly in `Cargo.toml` with `sed`, dropping the dependency on the custom action.

## Changes

```yaml
- name: Generate Package Version
  shell: pwsh
  run: Add-Content -Path $env:GITHUB_ENV -Value "VERSION=$('${{ github.event.release.tag_name }}'.substring(1))"

- name: Set Package Version
  run: sed -i "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/g" Cargo.toml
```

The `version = "..."` line in `Cargo.toml` matches the `sed` pattern, so the substitution works as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeFRLg2Hv9BuxiGEXtTW3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeFRLg2Hv9BuxiGEXtTW3N)_