### PR TITLE
ci: fix aarch64 cross-compile linker error

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Cross-compilation linker configuration.
+#
+# When building for aarch64 on an x86_64 host, cargo would otherwise invoke the
+# host's gcc/linker, which forces x86_64 ELF emulation onto the aarch64 objects
+# and fails with "incompatible with elf64-x86-64". Point the target at the
+# aarch64 cross-compiler (provided by the gcc-aarch64-linux-gnu package the
+# release workflow installs) so the correct linker and emulation are used.
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
## Summary

The `linux-arm64` release build was failing at the **link** step:

```
rust-lld: error: ... is incompatible with elf64-x86-64
error: linking with `cc` failed: exit status: 1
```

When cross-compiling for `aarch64-unknown-linux-gnu` on an x86_64 host, cargo was invoking the host x86_64 `gcc`/`cc` as the linker driver. That driver forces x86_64 ELF emulation (`elf64-x86-64`) onto the aarch64 object files, so the linker rejects them as incompatible.

## Fix

Add `.cargo/config.toml` pointing the `aarch64-unknown-linux-gnu` target at the aarch64 cross-compiler:

```toml
[target.aarch64-unknown-linux-gnu]
linker = "aarch64-linux-gnu-gcc"
```

`aarch64-linux-gnu-gcc` is already installed by the release workflow (the `gcc-aarch64-linux-gnu` apt package), so no workflow changes are needed. With the correct driver, the linker uses aarch64 emulation and the build links successfully.

The config is **target-scoped**, so x86_64 Linux, Windows, macOS, and `cargo test` builds are unaffected (verified the host build still compiles).

### Why not `cross` (like grey)?

grey uses the `cross` tool because it has native/OpenSSL dependencies. on-call is pure Rust (chrono, clap, serde, serde_json, serde_yaml) with no C/native deps, so the only thing missing for cross-compilation was the correct linker — no Docker/`cross` machinery required.

## Note

The build log also shows pre-existing `chrono` deprecation **warnings** (`NaiveDateTime::from_timestamp_opt`, `TimeDelta::max_value`) in `src/factors/recency.rs` and `src/factors/workload.rs`. These are not the cause of the failure (they're warnings, not errors) and appear on all platforms. Happy to clean them up in a separate change if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeFRLg2Hv9BuxiGEXtTW3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeFRLg2Hv9BuxiGEXtTW3N)_